### PR TITLE
Add CSV export functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 const Hapi = require('hapi')
 const mongoose = require('mongoose')
-const secret = require('./config')
 const env = require('./env')
 const validate = require('./app/util/validate')
 
@@ -12,15 +11,10 @@ app.connection({ host: '0.0.0.0', port: 3000, routes: { cors: { origin: ['*'] } 
 
 const db = env.MONGODB_URI
 
-app.register(require('hapi-auth-jwt2'), (err) => {
-  if (err) console.log(err)
+app.register(require('hapi-auth-basic'), (err) => {
+  if (err) throw err
 
-  app.auth.strategy('jwt', 'jwt', {
-    key: secret,
-    validateFunc: validate,
-    verifyOptions: { algorithms: ['HS256'] }
-  })
-
+  app.auth.strategy('simple', 'basic', { validateFunc: validate })
   app.route(routes)
 })
 

--- a/app/controllers/Admin.js
+++ b/app/controllers/Admin.js
@@ -1,0 +1,18 @@
+const CodeModel = require('../models/Code')
+const json2csv = require('json2csv')
+
+exports.exportAsCSV = {
+  auth: 'simple',
+  handler: (req, res) => {
+    CodeModel.getAllCodes((err, codes) => {
+      if (err) throw err
+      const fields = [ 'code', 'studentId' ]
+      let csv = json2csv({
+        data: codes,
+        fields: fields
+      })
+
+      return res(csv).type('text/csv')
+    })
+  }
+}

--- a/app/models/Admin.js
+++ b/app/models/Admin.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose')
+const Schema = mongoose.Schema
+
+const AdminSchema = new Schema({
+  username: { type: String, required: true },
+  password: { type: String, required: true }
+})
+
+const AdminModel = mongoose.model('Admins', AdminSchema)
+
+AdminSchema.index({ username: 1}, { unique: true })
+
+exports.findAdminByUsername = (username, callback) => {
+  AdminModel.findOne({ username: username }, callback)
+}

--- a/app/models/Code.js
+++ b/app/models/Code.js
@@ -33,4 +33,8 @@ exports.useCode = (code, studentId, callback) => {
   })
 }
 
+exports.getAllCodes = (callback) => {
+  CodeModel.find({}, { code: 1, studentId: 1 }, callback)
+}
+
 exports.CodeModel = CodeModel

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,7 +1,9 @@
 const User = require('./controllers/User.js')
+const Admin = require('./controllers/Admin.js')
 
 module.exports = [
 
-  { method: 'POST', path: '/get', config: User.useCode }
+  { method: 'POST', path: '/get', config: User.useCode },
+  { method: 'GET', path: '/export', config: Admin.exportAsCSV }
 
 ]

--- a/app/util/validate.js
+++ b/app/util/validate.js
@@ -1,23 +1,12 @@
+const AdminModel = require('../models/Admin')
 const Bcrypt = require('bcrypt')
 
-// TODO: Put this in Mongo
-const users = {
-  admin: {
-    username: 'admin',
-    password: '$2a$08$cGtwADl2Yxq2EgNe/r.x2OXQR5mgKcXSL7E/md.Oujf18HWeqbkhm',
-    name: 'Admin',
-    id: 0
-  }
-}
-
 const validate = (request, username, password, callback) => {
-  const user = users[username]
-  if (!user) {
-    return callback(null, false)
-  }
-
-  Bcrypt.compare(password, user.password, (err, isValid) => {
-    callback(err, isValid, { id: user.id, name: user.name })
+  AdminModel.findAdminByUsername(username, (err, user) => {
+    if (!user || err) return callback(null, false)
+    Bcrypt.compare(password, user.password, (err, isValid) => {
+      callback(err, isValid, { id: user.id })
+    })
   })
 }
 

--- a/app/util/validate.js
+++ b/app/util/validate.js
@@ -1,6 +1,24 @@
-const validate = (decoded, request, callback) => {
-  // TODO: Validate token
-  return callback(null, true)
+const Bcrypt = require('bcrypt')
+
+// TODO: Put this in Mongo
+const users = {
+  admin: {
+    username: 'admin',
+    password: '$2a$08$cGtwADl2Yxq2EgNe/r.x2OXQR5mgKcXSL7E/md.Oujf18HWeqbkhm',
+    name: 'Admin',
+    id: 0
+  }
+}
+
+const validate = (request, username, password, callback) => {
+  const user = users[username]
+  if (!user) {
+    return callback(null, false)
+  }
+
+  Bcrypt.compare(password, user.password, (err, isValid) => {
+    callback(err, isValid, { id: user.id, name: user.name })
+  })
 }
 
 module.exports = validate

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Hugo Müller-Downing",
   "license": "GPL-3.0",
   "dependencies": {
+    "bcrypt": "^0.8.7",
     "boom": "^3.2.2",
     "chai": "^3.5.0",
     "glob": "^7.0.5",
@@ -28,8 +29,10 @@
     "grunt-mocha-test": "^0.12.7",
     "grunt-nodemon": "^0.4.2",
     "hapi": "^13.5.0",
+    "hapi-auth-basic": "^4.2.0",
     "hapi-auth-jwt2": "^7.1.3",
     "joi": "^9.0.4",
+    "json2csv": "^3.6.3",
     "lodash": "^4.13.1",
     "mongoose": "^4.5.4",
     "path": "^0.12.7"


### PR DESCRIPTION
Exposes the `GET /export` route, which requires Basic Auth (username and password).

On authentication, the controller performs a lookup by username in the `admins` collection. This collection is not created by default, and has to be manually created and populated.

Passwords are stored as a Bcrypt hash. 

The endpoint returns a CSV of the format:

``` CSV
"code", "studentId",
"12345", "12341234"
"12345", "12341234"
```
